### PR TITLE
NECO-112 added .podspec 

### DIFF
--- a/RicohAPIAuth.podspec
+++ b/RicohAPIAuth.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "RicohAPIAuth"
+  s.version      = "1.0.1"
+  s.summary      = "Ricoh Auth Client"
+  s.description  = "Ricoh Auth Client in Swift"
+#  s.homepage     = "https://github.com/ricohapi/auth-swift"
+  s.homepage     = "https://github.com/hishida/auth-swift"
+  s.license      = "MIT"
+  s.author       = "Ricoh Company, Ltd."
+
+#  s.source       = { :git => "https://github.com/ricohapi/auth-swift.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/hishida/auth-swift.git", :tag => "#{s.version}" }
+  s.source_files  = "Source/*.swift"
+
+  s.ios.deployment_target = '9.0'
+end

--- a/RicohAPIAuth.podspec
+++ b/RicohAPIAuth.podspec
@@ -3,12 +3,12 @@ Pod::Spec.new do |s|
   s.version      = "1.0.1"
   s.summary      = "Ricoh Auth Client"
   s.description  = "Ricoh Auth Client in Swift"
-#  s.homepage     = "https://github.com/ricohapi/auth-swift"
-  s.homepage     = "https://github.com/hishida/auth-swift"
+  s.homepage     = "https://github.com/ricohapi/auth-swift"
   s.license      = "MIT"
   s.author       = "Ricoh Company, Ltd."
 
 #  s.source       = { :git => "https://github.com/ricohapi/auth-swift.git", :tag => "#{s.version}" }
+# delete if mstorage operation confirmation is OK.
   s.source       = { :git => "https://github.com/hishida/auth-swift.git", :tag => "#{s.version}" }
   s.source_files  = "Source/*.swift"
 


### PR DESCRIPTION
## Changes
- Created RicohAPIAuth.podspec.
## Tests

Tested the `pod lib lint` can pass.
1. Run `git clone --recursive https://github.com/hishida/auth-swift.git -b feature/NECO-112`
2. Run `cd auth-swift/`
3. Run `pod lib lint` and pass the test.
